### PR TITLE
fix bug of getting tags failed from a http registry

### DIFF
--- a/pkg/sync/destination.go
+++ b/pkg/sync/destination.go
@@ -69,6 +69,7 @@ func NewImageDestination(registry, repository, tag, username, password string, i
 		destinationRef: destRef,
 		destination:    rawDestination,
 		ctx:            ctx,
+		sysctx:         sysctx,
 		registry:       registry,
 		repository:     repository,
 		tag:            tag,

--- a/pkg/sync/source.go
+++ b/pkg/sync/source.go
@@ -73,6 +73,7 @@ func NewImageSource(registry, repository, tag, username, password string, insecu
 		sourceRef:  srcRef,
 		source:     rawSource,
 		ctx:        ctx,
+		sysctx:     sysctx,
 		registry:   registry,
 		repository: repository,
 		tag:        tag,


### PR DESCRIPTION
fix bug of getting tags failed from a http registry