### PR TITLE
fix self signed certificate error for private registry

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,9 +1,13 @@
 FROM golang:1.12.7 as builder
-COPY ./ /go/src/github.com/AliyunContainerService/image-syncer
 WORKDIR /go/src/github.com/AliyunContainerService/image-syncer
+COPY ./ ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 make
 
 FROM arm64v8/alpine:latest
-COPY --from=builder /go/src/github.com/AliyunContainerService/image-syncer/image-syncer /bin/
-RUN chmod +x /bin/image-syncer
-CMD ["image-syncer", "--config", "/etc/image-syncer/image-syncer.json"]
+WORKDIR /bin/
+COPY --from=builder /go/src/github.com/AliyunContainerService/image-syncer/image-syncer ./
+RUN chmod +x ./image-syncer
+RUN apk add -U --no-cache ca-certificates && rm -rf /var/cache/apk/* && mkdir -p /etc/ssl/certs \
+  && update-ca-certificates --fresh
+ENTRYPOINT ["image-syncer"]
+CMD ["--config", "/etc/image-syncer/image-syncer.json"]


### PR DESCRIPTION
Hi @hhyasdf I would like to submit a small PR for the self sign cert error I encounter while using it in private registry

#### changes made: ####

- [x] fix error `x509: certificate signed by unknown authority`, when I use self signed certificate for private registry, now with this fix I can do `docker run -v "$(pwd)/certs":/etc/ssl/certs  image-syncer:v1.0.3` without the same error
- [x] refactor for `CMD`, it's better to separate `ENTRYPOINT` and `CMD` as most of time we only update config parameters only
