### PR TITLE
refactor to make cmd clean phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: cmd clean
+
 cmd: $(wildcard ./pkg/client/*.go ./pkg/sync/*.go ./pkg/tools/*.go ./cmd/*.go ./*.go)
 	go build -o image-syncer ./main.go
 

--- a/main.go
+++ b/main.go
@@ -1,50 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"github.com/AliyunContainerService/image-syncer/cmd"
-	"os"
-	"os/signal"
-	"strconv"
-	"syscall"
-	"time"
-)
-
-const (
-	intervalEnv = "DEFAULT_SYNC_INTERVAL"
 )
 
 func main() {
-	intervalStr, found := os.LookupEnv(intervalEnv)
-	if !found || intervalStr == "" {
-		cmd.Execute()
-		return
-	}
-
-	interval, err := strconv.Atoi(intervalStr)
-	if err != nil {
-		panic(fmt.Errorf("invalid envar DEFAULT_SYNC_INTERVAL: %v", err))
-	}
-	intervalDuration := time.Duration(interval) * time.Second
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt, os.Kill, syscall.SIGTERM)
-	timer := time.NewTimer(intervalDuration)
-	defer timer.Stop()
-
-	for {
-		if !timer.Stop() {
-			select {
-			case <-timer.C:
-			default:
-			}
-		}
-		timer.Reset(intervalDuration)
-		select {
-		case <-quit:
-			return
-		case <-timer.C:
-			cmd.Execute()
-			continue
-		}
-	}
+	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,50 @@
 package main
 
 import (
+	"fmt"
 	"github.com/AliyunContainerService/image-syncer/cmd"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const (
+	intervalEnv = "DEFAULT_SYNC_INTERVAL"
 )
 
 func main() {
-	cmd.Execute()
+	intervalStr, found := os.LookupEnv(intervalEnv)
+	if !found || intervalStr == "" {
+		cmd.Execute()
+		return
+	}
+
+	interval, err := strconv.Atoi(intervalStr)
+	if err != nil {
+		panic(fmt.Errorf("invalid envar DEFAULT_SYNC_INTERVAL: %v", err))
+	}
+	intervalDuration := time.Duration(interval) * time.Second
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, os.Kill, syscall.SIGTERM)
+	timer := time.NewTimer(intervalDuration)
+	defer timer.Stop()
+
+	for {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(intervalDuration)
+		select {
+		case <-quit:
+			return
+		case <-timer.C:
+			cmd.Execute()
+			continue
+		}
+	}
 }


### PR DESCRIPTION
Hi @hhyasdf I would like to submit a small PR for the issue I encounter while using it in Kubernetes, the container pod keep restarting after sync task completion, which triggers a lot of false alerts for monitoring, therefore to enable recurring for sync task

#### changes made: ####

- [x] refactor: enable recurring for sync task, so no container pod restarts after sync task completion
- [x] refactor: make cmd clean phony to skip `make 'cmd' is up to date.` issue

