### PR TITLE
Display the full timestamp when log to os.Stderr

### DIFF
--- a/pkg/client/logger.go
+++ b/pkg/client/logger.go
@@ -6,12 +6,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const logTimestampFormat = "2006-01-02 15:04:05"
+
 // NewFileLogger creates a log file and init logger
 func NewFileLogger(path string) *logrus.Logger {
 	logger := logrus.New()
 
 	// default log to os.Stderr
 	if path == "" {
+		logger.Formatter = &logrus.TextFormatter{
+			FullTimestamp:   true,
+			TimestampFormat: logTimestampFormat,
+		}
 		return logger
 	}
 
@@ -23,7 +29,7 @@ func NewFileLogger(path string) *logrus.Logger {
 
 	// use json formatter
 	logger.Formatter = &logrus.JSONFormatter{
-		TimestampFormat: "2006-01-02 15:04:05",
+		TimestampFormat: logTimestampFormat,
 	}
 	return logger
 }


### PR DESCRIPTION
before:

```
ERRO[0003] Generate sync task quay.io/coreos/kube-rbac-proxy to quay.io/ruohe/kube-rbac-proxy error: get tags failed from quay.io/coreos/kube-rbac-proxy error: unable to retrieve auth token: invalid username/password 
```

after:

```
ERRO[2019-12-08 11:39:27] Generate sync task quay.io/coreos/kube-rbac-proxy to quay.io/ruohe/kube-rbac-proxy error: get tags failed from quay.io/coreos/kube-rbac-proxy error: unable to retrieve auth token: invalid username/password
```