### PR TITLE
Feature/platform selector

### DIFF
--- a/cmd/image-syncer.go
+++ b/cmd/image-syncer.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	logPath, configFile, authFile, imageFile, defaultRegistry, defaultNamespace string
+	logPath, configFile, authFile, imageFile, platformFile, defaultRegistry, defaultNamespace string
 
 	procNum, retries int
 )
@@ -24,7 +24,7 @@ var RootCmd = &cobra.Command{
 	Complete documentation is available at https://github.com/AliyunContainerService/image-syncer`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// work starts here
-		client, err := client.NewSyncClient(configFile, authFile, imageFile, logPath, procNum, retries, defaultRegistry, defaultNamespace)
+		client, err := client.NewSyncClient(configFile, authFile, imageFile, platformFile, logPath, procNum, retries, defaultRegistry, defaultNamespace)
 		if err != nil {
 			return fmt.Errorf("init sync client error: %v", err)
 		}
@@ -39,6 +39,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file path. This flag is deprecated and will be removed in the future. Please use --auth and --images instead.")
 	RootCmd.PersistentFlags().StringVar(&authFile, "auth", "", "auth file path. This flag need to be pair used with --images.")
 	RootCmd.PersistentFlags().StringVar(&imageFile, "images", "", "images file path. This flag need to be pair used with --auth")
+	RootCmd.PersistentFlags().StringVar(&platformFile, "platform", "", "platform file path. This flag is optional")
 	RootCmd.PersistentFlags().StringVar(&logPath, "log", "", "log file path (default in os.Stderr)")
 	RootCmd.PersistentFlags().StringVar(&defaultRegistry, "registry", os.Getenv("DEFAULT_REGISTRY"),
 		"default destinate registry url when destinate registry is not given in the config file, can also be set with DEFAULT_REGISTRY environment value")

--- a/example/platform.json
+++ b/example/platform.json
@@ -1,0 +1,7 @@
+{
+	"os": ["linux", "windows:10.0.17763.1998"],
+	"arch": ["arm:v7","amd64"],
+	"source": {
+		"exclude": ["quay.io/coreos/kube-rbac-proxy"]
+	}
+}

--- a/example/platform.yaml
+++ b/example/platform.yaml
@@ -2,4 +2,4 @@ os: [linux,windows:10.0.17763.1999]
 arch: [arm:v7,amd64]
 
 source:
-  include:  [quay.io/coreos/kube-rbac-proxy,hello-world]
+  include:  [quay.io/coreos/,hello-world]

--- a/example/platform.yaml
+++ b/example/platform.yaml
@@ -1,0 +1,5 @@
+os: [linux,windows:10.0.17763.1999]
+arch: [arm:v7,amd64]
+
+source:
+  include:  [quay.io/coreos/kube-rbac-proxy,hello-world]

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
+	github.com/tidwall/gjson v1.8.0
+	github.com/tidwall/pretty v1.2.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,14 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tidwall/gjson v1.8.0 h1:Qt+orfosKn0rbNTZqHYDqBrmm3UDA4KRkv70fDzG+PQ=
+github.com/tidwall/gjson v1.8.0/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"container/list"
 	"fmt"
+	"net/url"
 	"strings"
 	sync2 "sync"
 
@@ -43,10 +44,10 @@ type URLPair struct {
 }
 
 // NewSyncClient creates a synchronization client
-func NewSyncClient(configFile, authFile, imageFile, logFile string, routineNum, retries int, defaultDestRegistry string, defaultDestNamespace string) (*Client, error) {
+func NewSyncClient(configFile, authFile, imageFile, platformFile, logFile string, routineNum, retries int, defaultDestRegistry string, defaultDestNamespace string) (*Client, error) {
 	logger := NewFileLogger(logFile)
 
-	config, err := NewSyncConfig(configFile, authFile, imageFile, defaultDestRegistry, defaultDestNamespace)
+	config, err := NewSyncConfig(configFile, authFile, imageFile, platformFile, defaultDestRegistry, defaultDestNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("generate config error: %v", err)
 	}
@@ -170,6 +171,27 @@ func (c *Client) GenerateSyncTask(source string, destination string) ([]*URLPair
 		return nil, fmt.Errorf("source url should not be empty")
 	}
 
+	var platform *tools.Platform = &c.config.Platform
+
+	osArchSuffix := ""
+	// parse optional os/arch selector from tag , e.g foobar:1.2@platform:os=linux,windows:1912&arch=arm:v7,amd64
+	if pstr := strings.Split(source, PLATFORM_TAG); len(pstr) > 1 {
+		// generate a new platform matcher for this source
+		np := c.config.Platform
+		m, _ := url.ParseQuery(pstr[1])
+
+		// use repo specified os arch
+		if v, ok := m["os"]; ok {
+			np.OsList = strings.Split(v[0], ",")
+		}
+		if v, ok := m["arch"]; ok {
+			np.ArchList = strings.Split(v[0], ",")
+		}
+		platform = &np
+		source = pstr[0]
+		osArchSuffix = PLATFORM_TAG + pstr[1]
+	}
+
 	sourceURL, err := tools.NewRepoURL(source)
 	if err != nil {
 		return nil, fmt.Errorf("url %s format error: %v", source, err)
@@ -189,8 +211,9 @@ func (c *Client) GenerateSyncTask(source string, destination string) ([]*URLPair
 		return nil, fmt.Errorf("url %s format error: %v", destination, err)
 	}
 
-	// multi-tags config
 	tags := sourceURL.GetTag()
+
+	// multi-tags config
 	if moreTag := strings.Split(tags, ","); len(moreTag) > 1 {
 		if destURL.GetTag() != "" && destURL.GetTag() != sourceURL.GetTag() {
 			return nil, fmt.Errorf("multi-tags source should not correspond to a destination with tag: %s:%s", sourceURL.GetURL(), destURL.GetURL())
@@ -200,8 +223,8 @@ func (c *Client) GenerateSyncTask(source string, destination string) ([]*URLPair
 		var urlPairs = []*URLPair{}
 		for _, t := range moreTag {
 			urlPairs = append(urlPairs, &URLPair{
-				source:      sourceURL.GetURLWithoutTag() + ":" + t,
-				destination: destURL.GetURLWithoutTag() + ":" + t,
+				source:      sourceURL.GetURLWithoutTag() + ":" + t + osArchSuffix,
+				destination: destURL.GetURLWithoutTag() + ":" + t + osArchSuffix,
 			})
 		}
 
@@ -213,13 +236,13 @@ func (c *Client) GenerateSyncTask(source string, destination string) ([]*URLPair
 
 	if auth, exist := c.config.GetAuth(sourceURL.GetRegistry(), sourceURL.GetNamespace()); exist {
 		c.logger.Infof("Find auth information for %v, username: %v", sourceURL.GetURL(), auth.Username)
-		imageSource, err = sync.NewImageSource(sourceURL.GetRegistry(), sourceURL.GetRepoWithNamespace(), sourceURL.GetTag(), auth.Username, auth.Password, auth.Insecure)
+		imageSource, err = sync.NewImageSource(sourceURL.GetRegistry(), sourceURL.GetRepoWithNamespace(), sourceURL.GetTag(), auth.Username, auth.Password, auth.Insecure, platform)
 		if err != nil {
 			return nil, fmt.Errorf("generate %s image source error: %v", sourceURL.GetURL(), err)
 		}
 	} else {
 		c.logger.Infof("Cannot find auth information for %v, pull actions will be anonymous", sourceURL.GetURL())
-		imageSource, err = sync.NewImageSource(sourceURL.GetRegistry(), sourceURL.GetRepoWithNamespace(), sourceURL.GetTag(), "", "", false)
+		imageSource, err = sync.NewImageSource(sourceURL.GetRegistry(), sourceURL.GetRepoWithNamespace(), sourceURL.GetTag(), "", "", false, platform)
 		if err != nil {
 			return nil, fmt.Errorf("generate %s image source error: %v", sourceURL.GetURL(), err)
 		}
@@ -242,8 +265,8 @@ func (c *Client) GenerateSyncTask(source string, destination string) ([]*URLPair
 		var urlPairs = []*URLPair{}
 		for _, tag := range tags {
 			urlPairs = append(urlPairs, &URLPair{
-				source:      sourceURL.GetURL() + ":" + tag,
-				destination: destURL.GetURL() + ":" + tag,
+				source:      sourceURL.GetURL() + ":" + tag + osArchSuffix,
+				destination: destURL.GetURL() + ":" + tag + osArchSuffix,
 			})
 		}
 		return urlPairs, nil

--- a/pkg/sync/manifest.go
+++ b/pkg/sync/manifest.go
@@ -2,52 +2,91 @@ package sync
 
 import (
 	"fmt"
+	"io/ioutil"
 
 	"github.com/containers/image/v5/manifest"
+	"github.com/tidwall/gjson"
 )
 
 // ManifestHandler expends the ability of handling manifest list in schema2, but it's not finished yet
 // return the digest array of manifests in the manifest list if exist.
-func ManifestHandler(m []byte, t string, i *ImageSource) ([]manifest.Manifest, error) {
-
+func ManifestHandler(m []byte, t string, i *ImageSource, parent *manifest.Schema2List) ([]manifest.Manifest, interface{}, error) {
 	var manifestInfoSlice []manifest.Manifest
 
 	if t == manifest.DockerV2Schema2MediaType {
 		manifestInfo, err := manifest.Schema2FromManifest(m)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+
+		// platform info stored in config blob
+		if parent == nil && manifestInfo.ConfigInfo().Digest != "" {
+			blob, _, err := i.GetABlob(manifestInfo.ConfigInfo())
+			if err != nil {
+				return nil, nil, err
+			}
+			defer blob.Close()
+			bytes, err := ioutil.ReadAll(blob)
+			if err != nil {
+				return nil, nil, err
+			}
+			results := gjson.GetManyBytes(bytes, "architecture", "os")
+			if i.platformMatcher != nil && !i.platformMatcher.Match(i.registry, i.repository, i.tag, &manifest.Schema2PlatformSpec{Architecture: results[0].String(), OS: results[1].String()}) {
+				return manifestInfoSlice, manifestInfo, nil
+			}
+		}
+
 		manifestInfoSlice = append(manifestInfoSlice, manifestInfo)
-		return manifestInfoSlice, nil
+		return manifestInfoSlice, nil, nil
 	} else if t == manifest.DockerV2Schema1MediaType || t == manifest.DockerV2Schema1SignedMediaType {
 		manifestInfo, err := manifest.Schema1FromManifest(m)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+
+		// v1 only support architecture
+		if parent == nil && i.platformMatcher != nil && !i.platformMatcher.Match(i.registry, i.repository, i.tag, &manifest.Schema2PlatformSpec{Architecture: manifestInfo.Architecture}) {
+			return manifestInfoSlice, manifestInfo, nil
+		}
+
 		manifestInfoSlice = append(manifestInfoSlice, manifestInfo)
-		return manifestInfoSlice, nil
+		return manifestInfoSlice, nil, nil
 	} else if t == manifest.DockerV2ListMediaType {
 		manifestSchemaListInfo, err := manifest.Schema2ListFromManifest(m)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		for _, manifestDescriptorElem := range manifestSchemaListInfo.Manifests {
+		var nm []manifest.Schema2ManifestDescriptor
 
-			manifestByte, manifestType, err := i.source.GetManifest(i.ctx, &manifestDescriptorElem.Digest)
-			if err != nil {
-				return nil, err
+		for _, manifestDescriptorElem := range manifestSchemaListInfo.Manifests {
+			// select os arch as configed
+			if i.platformMatcher != nil && !i.platformMatcher.Match(i.registry, i.repository, i.tag, &manifestDescriptorElem.Platform) {
+				continue
 			}
 
-			platformSpecManifest, err := ManifestHandler(manifestByte, manifestType, i)
+			nm = append(nm, manifestDescriptorElem)
+			manifestByte, manifestType, err := i.source.GetManifest(i.ctx, &manifestDescriptorElem.Digest)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
+			}
+
+			platformSpecManifest, _, err := ManifestHandler(manifestByte, manifestType, i, manifestSchemaListInfo)
+			if err != nil {
+				return nil, nil, err
 			}
 
 			manifestInfoSlice = append(manifestInfoSlice, platformSpecManifest...)
 		}
-		return manifestInfoSlice, nil
+
+		// return a new Schema2List
+		if len(nm) != len(manifestSchemaListInfo.Manifests) {
+			manifestSchemaListInfo.Manifests = nm
+			return manifestInfoSlice, manifestSchemaListInfo, nil
+		} else {
+			return manifestInfoSlice, nil, nil
+		}
 	}
 
-	return nil, fmt.Errorf("unsupported manifest type: %v", t)
+	return nil, nil, fmt.Errorf("unsupported manifest type: %v", t)
 }

--- a/pkg/sync/task.go
+++ b/pkg/sync/task.go
@@ -65,9 +65,10 @@ func (t *Task) Run() error {
 			// pull a blob from source
 			blob, size, err := t.source.GetABlob(b)
 			if err != nil {
-				return t.Errorf("Get blob %s(%v) from %s/%s:%s failed: tools.PlatformReaderCloser{%v", b.Digest, size, t.source.GetRegistry(), t.source.GetRepository(), t.source.GetTag(), err)
+				return t.Errorf("Get blob %s(%v) from %s/%s:%s failed: %v", b.Digest, size, t.source.GetRegistry(), t.source.GetRepository(), t.source.GetTag(), err)
 			}
 			t.Infof("Get a blob %s(%v) from %s/%s:%s success", b.Digest, size, t.source.GetRegistry(), t.source.GetRepository(), t.source.GetTag())
+
 			b.Size = size
 			// push a blob to destination
 			if err := t.destination.PutABlob(blob, b); err != nil {
@@ -78,6 +79,7 @@ func (t *Task) Run() error {
 			// print the log of ignored blob
 			t.Infof("Blob %s(%v) has been pushed to %s, will not be pushed", b.Digest, b.Size, t.destination.GetRegistry()+"/"+t.destination.GetRepository())
 		}
+
 	}
 
 	//Push manifest list

--- a/pkg/sync/task.go
+++ b/pkg/sync/task.go
@@ -84,13 +84,12 @@ func (t *Task) Run() error {
 
 	//Push manifest list
 	if manifestType == manifest.DockerV2ListMediaType {
-		manifestSchemaListInfo := thisManifestInfo.(*manifest.Schema2List)
-		if manifestSchemaListInfo != nil {
-			// new manifest after platform selection
-			manifestByte, err = manifestSchemaListInfo.Serialize()
-			println(string(manifestByte))
-		} else {
+		var manifestSchemaListInfo *manifest.Schema2List
+		if thisManifestInfo == nil {
 			manifestSchemaListInfo, err = manifest.Schema2ListFromManifest(manifestByte)
+		} else {
+			manifestSchemaListInfo = thisManifestInfo.(*manifest.Schema2List)
+			manifestByte, err = manifestSchemaListInfo.Serialize()
 		}
 
 		if err != nil {

--- a/pkg/tools/platform.go
+++ b/pkg/tools/platform.go
@@ -1,0 +1,88 @@
+package tools
+
+import (
+	"strings"
+
+	"github.com/containers/image/v5/manifest"
+)
+
+type RepoFilter struct {
+	Registry   string
+	Repository string
+	Tag        string
+}
+
+// Platform selector of sync client
+type Platform struct {
+	// default os selectors, foramt: os[:version]
+	OsList []string `json:"os" yaml:"os"`
+	// default arch selectors, format: architecture[:variant]
+	ArchList []string `json:"arch" yaml:"arch"`
+
+	// set include or exclude filters for source image, when both are present, exclude filters take precedence
+	// filter string use repo url format: registry/namespace/repo:tag, empty field means match any
+	Source struct {
+		// include filters
+		Include []string `json:"include" yaml:"include"`
+
+		// exclude filters
+		Exclude []string `json:"exclude" yaml:"exclude"`
+
+		// Filers is exclude or include
+		IsExclude bool
+
+		// parsed filter
+		Filters []RepoFilter
+	} `json:"source" yaml:"source"`
+}
+
+// compare first:second to pat, second is optional
+func colonMatch(pat string, first string, second string) bool {
+	if strings.Index(pat, first) != 0 {
+		return false
+	}
+
+	return len(first) == len(pat) || (pat[len(first)] == ':' && pat[len(first)+1:] == second)
+}
+
+// Match platform selector according to the source image and its platform
+func (p *Platform) Match(registry string, repo string, tag string, platform *manifest.Schema2PlatformSpec) bool {
+	doSelect := p.Source.IsExclude
+
+	for _, p := range p.Source.Filters {
+		if (p.Registry == "" || p.Registry == registry) &&
+			(p.Repository == "" || p.Repository == repo) &&
+			(p.Tag == "" || p.Tag == tag) {
+			doSelect = !doSelect
+			break
+		}
+	}
+
+	if doSelect {
+		osMatched := true
+		archMatched := true
+		if len(p.OsList) != 0 {
+			osMatched = false
+			for _, o := range p.OsList {
+				// match os:osversion
+				if colonMatch(o, platform.OS, platform.OSVersion) {
+					osMatched = true
+				}
+			}
+		}
+
+		if len(p.ArchList) != 0 {
+			archMatched = false
+			for _, a := range p.ArchList {
+				// match architecture:variant
+				if colonMatch(a, platform.Architecture, platform.Variant) {
+					archMatched = true
+				}
+			}
+		}
+
+		return osMatched && archMatched
+	}
+
+	return true
+}

--- a/pkg/tools/platform.go
+++ b/pkg/tools/platform.go
@@ -51,7 +51,7 @@ func (p *Platform) Match(registry string, repo string, tag string, platform *man
 
 	for _, p := range p.Source.Filters {
 		if (p.Registry == "" || p.Registry == registry) &&
-			(p.Repository == "" || p.Repository == repo) &&
+			(p.Repository == "" || strings.HasPrefix(repo, p.Repository)) &&
 			(p.Tag == "" || p.Tag == tag) {
 			doSelect = !doSelect
 			break

--- a/pkg/tools/url.go
+++ b/pkg/tools/url.go
@@ -106,6 +106,11 @@ func (r *RepoURL) GetTag() string {
 	return r.tag
 }
 
+// SetTag returns the tag in a url
+func (r *RepoURL) SetTag(tag string) {
+	r.tag = tag
+}
+
 // GetRepoWithNamespace returns namespace/repository in a url
 func (r *RepoURL) GetRepoWithNamespace() string {
 	if r.namespace == "" {


### PR DESCRIPTION
目前大量的项目通过list manifest定义了多种操作系统和cpu架构镜像，搭建私有仓库时有的镜像很大却用不到，本pr增加了platform过滤的支持，可以在platform.yaml/json里配置或在images.yaml里通过inline tag的方式过滤，这样就只会拉取需要的系统镜像了。
1. 命令行增加--platform选项，可以指定配置文件，格式可以参考example内的示例。
2. images.yaml里支持对某个源镜像使用inline tag配置，示例：centos:centos7@platform:os=linux&arch=amd64,arm64，表示只获取linux下x64和arm64的镜像。