### PR TITLE
add macos release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux]
+        goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
-      - uses: wangyoucao577/go-release-action@v1.16
+      - uses: wangyoucao577/go-release-action@v1.30
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}


### PR DESCRIPTION

### Describe what this PR does / why we need it
As many people I use MacOS laptop in my work. Would be nice to have a release built for this OS too.

### Does this pull request fix one issue?
NONE

### Describe how you did it
depends on PR #103 without this changes `make` command failure run. 

### Describe how to verify it
-

### Special notes for reviews
Also I update to latest version go-release-binaries - see https://github.com/marketplace/actions/go-release-binaries