### PR TITLE
feat: support disable expand env param for auth

### DIFF
--- a/pkg/utils/types/auth.go
+++ b/pkg/utils/types/auth.go
@@ -2,7 +2,8 @@ package types
 
 // Auth describes the authentication information of a registry or a repository
 type Auth struct {
-	Username string `json:"username" yaml:"username"`
-	Password string `json:"password" yaml:"password"`
-	Insecure bool   `json:"insecure" yaml:"insecure"`
+	Username         string `json:"username" yaml:"username"`
+	Password         string `json:"password" yaml:"password"`
+	Insecure         bool   `json:"insecure" yaml:"insecure"`
+	DisableExpandEnv bool   `json:"disableexpandenv" yaml:"disableexpandenv"`
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/AliyunContainerService/image-syncer/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
auth 参数的行为不一致性。对于 **--config** , username/password中的${var}不会被替换，而 **--auth**， username/password中的${var}默认会被环境变量替换。



### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #151

### Describe how you did it
在Auth中新增一个disableexpandenv参数,默认值为False，即兼容了原有逻辑

### Describe how to verify it

### Special notes for reviews