### PR TITLE
修复manifestEqual方法缺陷

### DIFF
--- a/pkg/sync/destination.go
+++ b/pkg/sync/destination.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -214,11 +213,72 @@ func (i *ImageDestination) String() string {
 }
 
 func manifestEqual(m1, m2 []byte) bool {
-	var a bytes.Buffer
-	_ = json.Compact(&a, m1)
+	var a map[string]interface{}
+	var b map[string]interface{}
 
-	var b bytes.Buffer
-	_ = json.Compact(&b, m2)
+	json.Unmarshal(m1, &a)
+	json.Unmarshal(m2, &b)
 
-	return a.String() == b.String()
+	return compareMap(a, b)
+}
+
+func compareMap(map1, map2 map[string]interface{}) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+
+	for key, value1 := range map1 {
+		value2, ok := map2[key]
+		if !ok {
+			return false
+		}
+
+		switch v1 := value1.(type) {
+		case map[string]interface{}:
+			v2, ok := value2.(map[string]interface{})
+			if !ok || !compareMap(v1, v2) {
+				return false
+			}
+		case []interface{}:
+			v2, ok := value2.([]interface{})
+			if !ok || !compareSlice(v1, v2) {
+				return false
+			}
+		default:
+			if value1 != value2 {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func compareSlice(slice1, slice2 []interface{}) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+
+	for i, v1 := range slice1 {
+		v2 := slice2[i]
+
+		switch elem1 := v1.(type) {
+		case map[string]interface{}:
+			elem2, ok := v2.(map[string]interface{})
+			if !ok || !compareMap(elem1, elem2) {
+				return false
+			}
+		case []interface{}:
+			elem2, ok := v2.([]interface{})
+			if !ok || !compareSlice(elem1, elem2) {
+				return false
+			}
+		default:
+			if v1 != v2 {
+				return false
+			}
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/AliyunContainerService/image-syncer/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it

修复manifestEqual方法缺陷。
该方法的意图应当是对比来源和目标镜像的manifest，如果相同就skip该任务。但是该方法之前在本地和远程manifest内容实际上完全一致，但是key顺序不同的情况下，会返回false，没有成功比较。
而由于destManifest是本地构造的，因此key顺序大概率与远程不同。
这导致重复向远程仓库提交push；而在远程仓库开启immutable的情况下，会导致任务预期外的失败。


### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
是的，已测试

### Describe how you did it

将简单的json.compact成为无序byte数组的比较，转变成递归的key value逐个值比较，包括slice。

### Describe how to verify it
将目标镜像仓库设置immutable，也就是已存在的tag不允许重复提交；此时将来源和目标设置为相同地址进行提交，在原始版本会报错。
unknown: The requested tag already exists and cannot be overwritten
当前提交版本会提示 skip synchronization because destination image exists 并返回成功

### Special notes for reviews